### PR TITLE
Use sort with key= instead of cmp=

### DIFF
--- a/Lib/extractFea/extract.py
+++ b/Lib/extractFea/extract.py
@@ -419,7 +419,7 @@ class Selector(object):
             if rule is not None:
                 result.append(rule)
         # shortest rule first, may speed up selecting a bit
-        result.sort(cmp=lambda x,y:len(x)-len(y))
+        result.sort(key=len)
         return result;
 
     def _ruleSelects(self, rule, item):


### PR DESCRIPTION
This is an attempt at continuing your initial work to get `extractFea` to work with Python 3. `cmp=` is [no longer available](https://docs.python.org/3.9/howto/sorting.html#the-old-way-using-the-cmp-parameter).